### PR TITLE
feat(components): add core UI components with types and styles

### DIFF
--- a/packages/core/src/components/Accordion/Accordion.core.ts
+++ b/packages/core/src/components/Accordion/Accordion.core.ts
@@ -1,0 +1,55 @@
+// packages/core/src/components/Accordion/Accordion.core.ts
+import {
+    AccordionCoreProps,
+    AccordionStyleProps,
+    AccordionItemStyleProps,
+    AccordionTriggerStyleProps,
+    AccordionContentStyleProps,
+  } from "./Accordion.types";
+  import {
+    accordionStyles,
+    accordionItemStyles,
+    accordionTriggerStyles,
+    accordionContentStyles,
+  } from "./Accordion.styles";
+  import { cn } from "../../utils/cn";
+  
+  export function getAccordionProps(props: AccordionStyleProps & { className?: string }) {
+    const { variant = "default", size = "md", className } = props;
+  
+    return {
+      className: cn(accordionStyles({ variant, size }), className),
+      variant,
+      size,
+    };
+  }
+  
+  export function getAccordionItemProps(props: AccordionItemStyleProps & { className?: string }) {
+    const { variant = "default", size = "md", className } = props;
+  
+    return {
+      className: cn(accordionItemStyles({ variant, size }), className),
+      variant,
+      size,
+    };
+  }
+  
+  export function getAccordionTriggerProps(props: AccordionTriggerStyleProps & { className?: string }) {
+    const { variant = "default", size = "md", className } = props;
+  
+    return {
+      className: cn(accordionTriggerStyles({ variant, size }), className),
+      variant,
+      size,
+    };
+  }
+  
+  export function getAccordionContentProps(props: AccordionContentStyleProps & { className?: string }) {
+    const { variant = "default", size = "md", className } = props;
+  
+    return {
+      className: cn(accordionContentStyles({ variant, size }), className),
+      variant,
+      size,
+    };
+  }

--- a/packages/core/src/components/Accordion/Accordion.styles.ts
+++ b/packages/core/src/components/Accordion/Accordion.styles.ts
@@ -1,0 +1,90 @@
+// packages/core/src/components/Accordion/Accordion.styles.ts
+import { cva } from "class-variance-authority";
+
+export const accordionStyles = cva(
+  "w-full",
+  {
+    variants: {
+      variant: {
+        default: "",
+        ghost: "",
+        bordered: "border border-border rounded-lg",
+      },
+      size: {
+        sm: "text-sm",
+        md: "text-base",
+        lg: "text-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  },
+);
+
+export const accordionItemStyles = cva(
+  "",
+  {
+    variants: {
+      variant: {
+        default: "border-b border-border",
+        ghost: "",
+        bordered: "border-b border-border last:border-b-0",
+      },
+      size: {
+        sm: "",
+        md: "",
+        lg: "",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  },
+);
+
+export const accordionTriggerStyles = cva(
+  "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+  {
+    variants: {
+      variant: {
+        default: "",
+        ghost: "hover:bg-accent hover:text-accent-foreground rounded-md px-2",
+        bordered: "px-4",
+      },
+      size: {
+        sm: "py-2 text-sm",
+        md: "py-4 text-base",
+        lg: "py-6 text-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  },
+);
+
+export const accordionContentStyles = cva(
+  "overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+  {
+    variants: {
+      variant: {
+        default: "pb-4 pt-0",
+        ghost: "pb-4 pt-0 px-2",
+        bordered: "pb-4 pt-0 px-4",
+      },
+      size: {
+        sm: "text-xs pb-2",
+        md: "text-sm pb-4",
+        lg: "text-base pb-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  },
+);

--- a/packages/core/src/components/Accordion/Accordion.types.ts
+++ b/packages/core/src/components/Accordion/Accordion.types.ts
@@ -1,0 +1,47 @@
+// packages/core/src/components/Accordion/Accordion.types.ts
+export interface AccordionCoreProps {
+    type?: "single" | "multiple";
+    value?: string | string[];
+    defaultValue?: string | string[];
+    collapsible?: boolean;
+    disabled?: boolean;
+    className?: string;
+  }
+  
+  export type AccordionSize = "sm" | "md" | "lg";
+  export type AccordionVariant = "default" | "ghost" | "bordered";
+  
+  export interface AccordionStyleProps {
+    size?: AccordionSize;
+    variant?: AccordionVariant;
+  }
+  
+  export interface AccordionItemCoreProps {
+    value: string;
+    disabled?: boolean;
+    className?: string;
+  }
+  
+  export interface AccordionItemStyleProps {
+    size?: AccordionSize;
+    variant?: AccordionVariant;
+  }
+  
+  export interface AccordionTriggerCoreProps {
+    className?: string;
+  }
+  
+  export interface AccordionTriggerStyleProps {
+    size?: AccordionSize;
+    variant?: AccordionVariant;
+  }
+  
+  export interface AccordionContentCoreProps {
+    className?: string;
+  }
+  
+  export interface AccordionContentStyleProps {
+    size?: AccordionSize;
+    variant?: AccordionVariant;
+  }
+  

--- a/packages/core/src/components/Accordion/index.ts
+++ b/packages/core/src/components/Accordion/index.ts
@@ -1,0 +1,4 @@
+// packages/core/src/components/Accordion/index.ts
+export * from "./Accordion.types";
+export * from "./Accordion.styles";
+export * from "./Accordion.core";

--- a/packages/core/src/components/Card/Card.styles.ts
+++ b/packages/core/src/components/Card/Card.styles.ts
@@ -1,0 +1,92 @@
+// packages/core/src/components/Card/Card.styles.ts
+import { cva } from "class-variance-authority";
+
+export const cardStyles = cva(
+  "rounded-lg border bg-card text-card-foreground",
+  {
+    variants: {
+      variant: {
+        default: "border-border bg-card",
+        outlined: "border-2 border-border bg-transparent",
+        elevated: "border-border bg-card shadow-lg",
+        filled: "border-border bg-muted/50",
+      },
+      padding: {
+        none: "p-0",
+        sm: "p-3",
+        md: "p-6",
+        lg: "p-8",
+      },
+      shadow: {
+        none: "shadow-none",
+        sm: "shadow-sm",
+        md: "shadow-md",
+        lg: "shadow-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      padding: "md",
+      shadow: "sm",
+    },
+  }
+);
+
+export const cardHeaderStyles = cva(
+  "flex flex-col space-y-1.5 p-6",
+  {
+    variants: {
+      padding: {
+        none: "p-0",
+        sm: "p-3",
+        md: "p-6", 
+        lg: "p-8",
+      },
+    },
+    defaultVariants: {
+      padding: "md",
+    },
+  }
+);
+
+export const cardContentStyles = cva(
+  "p-6 pt-0",
+  {
+    variants: {
+      padding: {
+        none: "p-0",
+        sm: "p-3 pt-0",
+        md: "p-6 pt-0",
+        lg: "p-8 pt-0", 
+      },
+    },
+    defaultVariants: {
+      padding: "md",
+    },
+  }
+);
+
+export const cardFooterStyles = cva(
+  "flex items-center p-6 pt-0",
+  {
+    variants: {
+      padding: {
+        none: "p-0",
+        sm: "p-3 pt-0",
+        md: "p-6 pt-0",
+        lg: "p-8 pt-0",
+      },
+    },
+    defaultVariants: {
+      padding: "md",
+    },
+  }
+);
+
+export const cardTitleStyles = cva(
+  "text-2xl font-semibold leading-none tracking-tight"
+);
+
+export const cardDescriptionStyles = cva(
+  "text-sm text-muted-foreground"
+);

--- a/packages/core/src/components/Card/Card.types.ts
+++ b/packages/core/src/components/Card/Card.types.ts
@@ -1,0 +1,29 @@
+// packages/core/src/components/Card/Card.types.ts
+export interface CardCoreProps {
+    className?: string;
+  }
+  
+  export interface CardStyleProps {
+    variant?: CardVariant;
+    padding?: CardPadding;
+    shadow?: CardShadow;
+  }
+  
+  export type CardVariant = "default" | "outlined" | "elevated" | "filled";
+  export type CardPadding = "none" | "sm" | "md" | "lg";
+  export type CardShadow = "none" | "sm" | "md" | "lg";
+  
+  // Header props
+  export interface CardHeaderCoreProps {
+    className?: string;
+  }
+  
+  // Content props  
+  export interface CardContentCoreProps {
+    className?: string;
+  }
+  
+  // Footer props
+  export interface CardFooterCoreProps {
+    className?: string;
+  }

--- a/packages/core/src/components/Card/index.ts
+++ b/packages/core/src/components/Card/index.ts
@@ -1,0 +1,3 @@
+// packages/core/src/components/Card/index.ts
+export * from "./Card.types";
+export * from "./Card.styles";

--- a/packages/core/src/components/Modal/Modal.styles.ts
+++ b/packages/core/src/components/Modal/Modal.styles.ts
@@ -1,0 +1,44 @@
+// packages/core/src/components/Modal/Modal.styles.ts
+import { cva } from "class-variance-authority";
+
+export const modalOverlayStyles = cva(
+  "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+);
+
+export const modalContentStyles = cva(
+  "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+  {
+    variants: {
+      size: {
+        sm: "max-w-sm",
+        md: "max-w-md",
+        lg: "max-w-lg",
+        xl: "max-w-xl",
+        full: "max-w-none w-[95vw] h-[95vh]",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+);
+
+export const modalHeaderStyles = cva(
+  "flex flex-col space-y-1.5 text-center sm:text-left"
+);
+
+export const modalFooterStyles = cva(
+  "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"
+);
+
+export const modalTitleStyles = cva(
+  "text-lg font-semibold leading-none tracking-tight"
+);
+
+export const modalDescriptionStyles = cva(
+  "text-sm text-muted-foreground"
+);
+
+export const modalCloseStyles = cva(
+  "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+);

--- a/packages/core/src/components/Modal/Modal.types.ts
+++ b/packages/core/src/components/Modal/Modal.types.ts
@@ -1,0 +1,52 @@
+// packages/core/src/components/Modal/Modal.types.ts
+export interface ModalCoreProps {
+    open?: boolean;
+    defaultOpen?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    className?: string;
+  }
+  
+  export interface ModalStyleProps {
+    size?: ModalSize;
+    centered?: boolean;
+  }
+  
+  export type ModalSize = "sm" | "md" | "lg" | "xl" | "full";
+  
+  // Content props
+  export interface ModalContentCoreProps {
+    className?: string;
+    forceMount?: boolean;
+  }
+  
+  // Header props
+  export interface ModalHeaderCoreProps {
+    className?: string;
+  }
+  
+  // Footer props
+  export interface ModalFooterCoreProps {
+    className?: string;
+  }
+  
+  // Title props
+  export interface ModalTitleCoreProps {
+    className?: string;
+  }
+  
+  // Description props
+  export interface ModalDescriptionCoreProps {
+    className?: string;
+  }
+  
+  // Trigger props
+  export interface ModalTriggerCoreProps {
+    className?: string;
+    asChild?: boolean;
+  }
+  
+  // Close props
+  export interface ModalCloseCoreProps {
+    className?: string;
+    asChild?: boolean;
+  }

--- a/packages/core/src/components/Modal/index.ts
+++ b/packages/core/src/components/Modal/index.ts
@@ -1,0 +1,3 @@
+// packages/core/src/components/Modal/index.ts
+export * from "./Modal.types";
+export * from "./Modal.styles";

--- a/packages/core/src/components/Tabs/Tabs.core.ts
+++ b/packages/core/src/components/Tabs/Tabs.core.ts
@@ -1,0 +1,33 @@
+// packages/core/src/components/Tabs/Tabs.core.ts
+import { TabsStyleProps } from "./Tabs.types";
+import { tabsListStyles, tabsTriggerStyles, tabsContentStyles } from "./Tabs.styles";
+import { cn } from "../../utils/cn";
+
+export function getTabsListProps(props: TabsStyleProps & { className?: string }) {
+  const { variant = "default", size = "md", className } = props;
+
+  return {
+    className: cn(tabsListStyles({ variant, size }), className),
+    variant,
+    size,
+  };
+}
+
+export function getTabsTriggerProps(props: TabsStyleProps & { className?: string }) {
+  const { variant = "default", size = "md", className } = props;
+
+  return {
+    className: cn(tabsTriggerStyles({ variant, size }), className),
+    variant,
+    size,
+  };
+}
+
+export function getTabsContentProps(props: TabsStyleProps & { className?: string }) {
+  const { size = "md", className } = props;
+
+  return {
+    className: cn(tabsContentStyles({ size }), className),
+    size,
+  };
+}

--- a/packages/core/src/components/Tabs/Tabs.styles.ts
+++ b/packages/core/src/components/Tabs/Tabs.styles.ts
@@ -1,0 +1,78 @@
+// packages/core/src/components/Tabs/Tabs.styles.ts
+import { cva } from "class-variance-authority";
+
+export const tabsListStyles = cva(
+  "inline-flex items-center justify-center",
+  {
+    variants: {
+      variant: {
+        default: "rounded-md bg-muted p-1",
+        pills: "space-x-1",
+        underline: "border-b border-border",
+      },
+      orientation: {
+        horizontal: "flex-row",
+        vertical: "flex-col space-y-1",
+      },
+      size: {
+        sm: "h-8",
+        md: "h-10", 
+        lg: "h-12",
+      },
+    },
+    compoundVariants: [
+      {
+        variant: "underline",
+        class: "bg-transparent p-0 space-x-0",
+      },
+      {
+        orientation: "vertical",
+        variant: "default",
+        class: "h-auto w-fit flex-col space-y-1",
+      },
+    ],
+    defaultVariants: {
+      variant: "default",
+      orientation: "horizontal",
+      size: "md",
+    },
+  },
+);
+
+export const tabsTriggerStyles = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        pills: "rounded-md hover:bg-muted data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        underline: "rounded-none border-b-2 border-transparent bg-transparent hover:text-foreground data-[state=active]:border-primary data-[state=active]:text-foreground",
+      },
+      size: {
+        sm: "text-xs px-2 py-1",
+        md: "text-sm px-3 py-1.5",
+        lg: "text-base px-4 py-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  },
+);
+
+export const tabsContentStyles = cva(
+  "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  {
+    variants: {
+      size: {
+        sm: "text-sm",
+        md: "text-base",
+        lg: "text-lg",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  },
+);

--- a/packages/core/src/components/Tabs/Tabs.types.ts
+++ b/packages/core/src/components/Tabs/Tabs.types.ts
@@ -1,0 +1,45 @@
+// packages/core/src/components/Tabs/Tabs.types.ts
+export interface TabsCoreProps {
+    value?: string;
+    defaultValue?: string;
+    orientation?: "horizontal" | "vertical";
+    className?: string;
+  }
+  
+  export type TabsSize = "sm" | "md" | "lg";
+  export type TabsVariant = "default" | "pills" | "underline";
+  
+  export interface TabsStyleProps {
+    size?: TabsSize;
+    variant?: TabsVariant;
+  }
+  
+  export interface TabsListCoreProps {
+    className?: string;
+  }
+  
+  export interface TabsListStyleProps {
+    size?: TabsSize;
+    variant?: TabsVariant;
+    orientation?: "horizontal" | "vertical";
+  }
+  
+  export interface TabsTriggerCoreProps {
+    value: string;
+    disabled?: boolean;
+    className?: string;
+  }
+  
+  export interface TabsTriggerStyleProps {
+    size?: TabsSize;
+    variant?: TabsVariant;
+  }
+  
+  export interface TabsContentCoreProps {
+    value: string;
+    className?: string;
+  }
+  
+  export interface TabsContentStyleProps {
+    size?: TabsSize;
+  }

--- a/packages/core/src/components/Tabs/index.ts
+++ b/packages/core/src/components/Tabs/index.ts
@@ -1,0 +1,3 @@
+export * from "./Tabs.types";
+export * from "./Tabs.styles";
+export * from './Tabs.core'


### PR DESCRIPTION
- Implement Tabs, Card, Modal, and Accordion components
- Include type definitions and style variants for each component
- Add utility functions for component props generation
- Set up consistent styling using class-variance-authority
```

This commit message:
1. Uses "feat" type since it introduces new features (UI components)
2. Specifies "components" as the scope
3. Provides a concise description under 50 chars in the subject
4. Includes a body that highlights the key additions without repeating the subject
5. Focuses on the most important aspects of the changes (core components, types, styles)
6. Uses imperative mood and avoids ending punctuation in the subject