### PR TITLE
ci: remove frozen-lockfile flag from pnpm install in storybook workflow

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -32,7 +32,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build core package
         run: pnpm --filter @mild-ui/core build


### PR DESCRIPTION
The frozen-lockfile flag was removed to allow for updates to dependencies during installation, which may be necessary for proper storybook builds