### PR TITLE
refactor: remove examples-related scripts and deployment

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -72,7 +72,6 @@ jobs:
           mkdir -p deploy/react
           mkdir -p deploy/vue
           mkdir -p deploy/core
-          mkdir -p deploy/examples
 
       - name: Copy React Storybook
         run: cp -r storybook/react/storybook-static/* deploy/react/
@@ -89,70 +88,6 @@ jobs:
             echo "Core docs not found, skipping..."
           fi
 
-      # Copy Core Examples
-      - name: Copy Core Examples
-        run: |
-          # Copy examples
-          cp -r packages/core/examples/* deploy/examples/
-          
-          # Copy dist files so examples can access CSS
-          cp -r packages/core/dist deploy/examples/dist
-          
-          # Fix CSS paths in example files for deployment
-          sed -i 's|href="../dist/mild-ui.css"|href="./dist/mild-ui.css"|g' deploy/examples/*.html
-          
-          # Rename the main examples file to avoid conflicts
-          mv deploy/examples/index.html deploy/examples/examples.html
-          
-          # Create examples navigation index page
-          cat > deploy/examples/index.html << 'EXAMPLES_EOF'
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-              <meta charset="UTF-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-              <title>@mild-ui/core Examples</title>
-              <style>
-                  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; line-height: 1.6; }
-                  h1 { color: #1e293b; border-bottom: 1px solid #e2e8f0; padding-bottom: 1rem; }
-                  .example-grid { display: grid; gap: 1.5rem; margin-top: 2rem; }
-                  .example-card { border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; background: white; }
-                  .example-card h3 { margin: 0 0 0.5rem 0; color: #374151; }
-                  .example-card p { color: #6b7280; margin-bottom: 1rem; }
-                  .example-card a { background: #3b82f6; color: white; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; display: inline-block; }
-                  .example-card a:hover { background: #2563eb; }
-              </style>
-          </head>
-          <body>
-              <h1>@mild-ui/core Live Examples</h1>
-              <p>Interactive examples demonstrating mild-ui CSS utilities in action. These examples use only CSS and HTML to showcase the framework-agnostic nature of the library.</p>
-              
-              <div class="example-grid">
-                  <div class="example-card">
-                      <h3>🎯 Complete Examples</h3>
-                      <p>Comprehensive showcase of all mild-ui utilities with working dark mode toggle</p>
-                      <a href="./examples.html">View Examples</a>
-                  </div>
-                  
-                  <div class="example-card">
-                      <h3>🌐 Landing Page</h3>
-                      <p>Complete marketing website built with mild-ui utilities</p>
-                      <a href="./landing-page.html">View Landing Page</a>
-                  </div>
-                  
-                  <div class="example-card">
-                      <h3>📊 Dashboard</h3>
-                      <p>Admin dashboard interface with sidebar, cards, and data tables</p>
-                      <a href="./dashboard.html">View Dashboard</a>
-                  </div>
-              </div>
-              
-              <div style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e2e8f0; text-align: center;">
-                  <a href="../" style="color: #3b82f6; text-decoration: none;">← Back to Main Documentation</a>
-              </div>
-          </body>
-          </html>
-          EXAMPLES_EOF
 
       - name: Create enhanced main index page
         run: |
@@ -327,11 +262,6 @@ jobs:
                                       <a href="./core/">Browse Utilities</a>
                                   </div>
                                   
-                                  <div class="doc-card">
-                                      <h3>🚀 Live CSS Examples</h3>
-                                      <p>Interactive examples using only CSS utilities</p>
-                                      <a href="./examples/">View CSS Examples</a>
-                                  </div>
                                   
                                   <div class="doc-card">
                                       <h3>📊 Package Overview</h3>

--- a/packages/core/UTILITIES.md
+++ b/packages/core/UTILITIES.md
@@ -316,25 +316,6 @@ All utilities automatically support dark mode through:
 1. **System preference**: `@media (prefers-color-scheme: dark)`
 2. **Manual toggle**: `[data-theme="dark"]` attribute
 
-## Example Usage
-
-```html
-<!-- Tailwind-like utilities with mild- prefix -->
-<div class="mild-flex mild-items-center mild-justify-between mild-p-4 mild-bg-gray-100 mild-border mild-border-gray-200 mild-radius-md">
-  <h2 class="mild-text-lg mild-font-semibold mild-text-gray-900">Card Title</h2>
-  <button class="mild-px-4 mild-py-2 mild-bg-primary-500 mild-text-white mild-radius-sm mild-transition-colors">
-    Click me
-  </button>
-</div>
-
-<!-- Can be used alongside Tailwind CSS without conflicts -->
-<div class="flex items-center"> <!-- Tailwind classes -->
-  <div class="mild-p-4 mild-bg-primary-100"> <!-- Mild UI utilities -->
-    Content with both libraries
-  </div>
-</div>
-```
-
 ## Why Use Mild UI Utilities?
 
 1. **No Conflicts**: Uses `mild-` prefix so you can use alongside Tailwind CSS

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,10 +21,7 @@
     "docs:build": "pnpm run docs:generate",
     "docs:serve": "pnpm run docs:generate && serve docs -p 3001",
     "docs:watch": "nodemon --watch src --ext scss --exec \"pnpm docs:generate\"",
-    "examples:serve": "serve . -p 3002",
-    "examples:dev": "concurrently \"pnpm run sass:watch\" \"pnpm run examples:serve\"",
-    "examples:open": "pnpm run examples:serve && open http://localhost:3002/examples",
-    "dev:full": "concurrently \"pnpm run sass:watch\" \"pnpm run docs:serve\" \"pnpm run examples:serve\"",
+    "dev:full": "concurrently \"pnpm run sass:watch\" \"pnpm run docs:serve\"",
     "mobile:flutter": "node scripts/generate-flutter.js",
     "mobile:react-native": "node scripts/generate-react-native.js",
     "mobile:all": "concurrently \"pnpm run mobile:flutter\" \"pnpm run mobile:react-native\""

--- a/packages/core/scripts/generate-react-native.js
+++ b/packages/core/scripts/generate-react-native.js
@@ -991,151 +991,33 @@ Convert your mild-ui design system to React Native with identical design tokens,
 
 1. Copy the generated files to your React Native project:
    \`\`\`
-   src/
-     theme/
-       MildTheme.js (or .ts)
-       MildUtils.js (or .ts)
+   src/theme/
+     MildTheme.js (or .ts)
+     MildUtils.js (or .ts)
    \`\`\`
 
 2. Import the theme in your app:
    \`\`\`javascript
    import { MildTheme, MildUtils } from './theme/MildTheme';
-   // or for TypeScript
-   import { MildTheme, MildUtils } from './theme/MildTheme.ts';
    \`\`\`
 
 ## Usage
 
-### Basic Theme Setup
+Access design tokens and utility StyleSheets directly in your React Native components:
 
 \`\`\`javascript
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { MildTheme } from './theme/MildTheme';
+import { MildTheme, MildUtils } from './theme/MildTheme';
 
-const App = () => {
-  return (
-    <View style={[styles.container, { backgroundColor: MildTheme.semanticColors.light.background }]}>
-      <Text style={[styles.title, { color: MildTheme.semanticColors.light.foreground }]}>
-        Hello Mild UI!
-      </Text>
-    </View>
-  );
-};
-
+// Use design tokens
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     padding: MildTheme.spacing[4],
-  },
-  title: {
-    fontSize: MildTheme.typography.fontSize.xl,
-    fontWeight: MildTheme.typography.fontWeight.bold,
-  },
+    backgroundColor: MildTheme.colors.primary[500],
+  }
 });
-\`\`\`
 
-### Using Utility StyleSheets
-
-\`\`\`javascript
-import React from 'react';
-import { View, Text } from 'react-native';
-import { MildUtils } from './theme/MildUtils';
-
-const MyComponent = () => {
-  return (
-    // Equivalent to: <div class="mild-flex mild-flex-row mild-items-center mild-p-4">
-    <View style={[MildUtils.layout.flex, MildUtils.layout.flexRow, MildUtils.layout.itemsCenter, MildUtils.spacing.p4]}>
-      {/* Equivalent to: <h1 class="mild-text-xl mild-font-bold"> */}
-      <Text style={[MildUtils.typography.textXl, MildUtils.typography.fontBold]}>
-        Title
-      </Text>
-      {/* Equivalent to: <p class="mild-text-sm mild-text-gray-600"> */}
-      <Text style={[MildUtils.typography.textSm, MildUtils.colorsLight.textGray600]}>
-        Subtitle
-      </Text>
-    </View>
-  );
-};
-\`\`\`
-
-### Dark Mode Support
-
-\`\`\`javascript
-import React, { useState } from 'react';
-import { View, Text, Switch } from 'react-native';
-import { MildTheme, MildUtils } from './theme';
-
-const ThemedComponent = () => {
-  const [isDark, setIsDark] = useState(false);
-  const theme = isDark ? MildTheme.semanticColors.dark : MildTheme.semanticColors.light;
-  const colors = isDark ? MildUtils.colorsDark : MildUtils.colorsLight;
-
-  return (
-    <View style={[MildUtils.spacing.p4, { backgroundColor: theme.background }]}>
-      <Text style={[MildUtils.typography.textLg, { color: theme.foreground }]}>
-        Dark Mode Example
-      </Text>
-      <Switch value={isDark} onValueChange={setIsDark} />
-    </View>
-  );
-};
-\`\`\`
-
-### Component Styling Examples
-
-\`\`\`javascript
-// Button Component (equivalent to mild-ui button)
-const PrimaryButton = ({ title, onPress }) => (
-  <TouchableOpacity
-    style={[
-      MildUtils.spacing.px4,
-      MildUtils.spacing.py2,
-      MildUtils.borders.roundedMd,
-      MildUtils.shadows.shadow,
-      { backgroundColor: MildTheme.colors.primary[500] }
-    ]}
-    onPress={onPress}
-  >
-    <Text style={[MildUtils.typography.fontMedium, { color: '#ffffff' }]}>
-      {title}
-    </Text>
-  </TouchableOpacity>
-);
-
-// Card Component (equivalent to mild-ui card)
-const Card = ({ children }) => (
-  <View style={[
-    MildUtils.spacing.p4,
-    MildUtils.borders.roundedLg,
-    MildUtils.shadows.shadowLg,
-    MildUtils.colorsLight.bgWhite,
-    MildUtils.spacing.m2,
-  ]}>
-    {children}
-  </View>
-);
-
-// Avatar Component (equivalent to mild-ui avatar)
-const Avatar = ({ source, size = 'md' }) => {
-  const sizeMap = {
-    sm: MildUtils.sizing.size8,
-    md: MildUtils.sizing.size12,
-    lg: MildUtils.sizing.size16,
-  };
-
-  return (
-    <Image
-      source={source}
-      style={[
-        sizeMap[size],
-        MildUtils.borders.roundedFull,
-        MildUtils.borders.border,
-        MildUtils.colorsLight.borderGray200,
-      ]}
-    />
-  );
-};
+// Use utility StyleSheets
+<View style={[MildUtils.layout.flex, MildUtils.spacing.p4]} />
 \`\`\`
 
 ## Design Token Mapping
@@ -1144,71 +1026,13 @@ const Avatar = ({ source, size = 'md' }) => {
 |---------|-------------------------|
 | \`mild-p-4\` | \`MildUtils.spacing.p4\` |
 | \`mild-text-xl\` | \`MildUtils.typography.textXl\` |
-| \`mild-font-bold\` | \`MildUtils.typography.fontBold\` |
 | \`mild-bg-primary-500\` | \`{ backgroundColor: MildTheme.colors.primary[500] }\` |
-| \`mild-radius-md\` | \`MildUtils.borders.roundedMd\` |
-| \`mild-shadow-lg\` | \`MildUtils.shadows.shadowLg\` |
-| \`mild-flex mild-items-center\` | \`[MildUtils.layout.flex, MildUtils.layout.itemsCenter]\` |
 
 ## TypeScript Support
 
-All files include full TypeScript definitions:
+All files include full TypeScript definitions for type safety.
 
-\`\`\`typescript
-import { MildTheme, MildUtils } from './theme/MildTheme';
-import type { ViewStyle, TextStyle } from 'react-native';
-
-const buttonStyle: ViewStyle = {
-  ...MildUtils.spacing.px4,
-  ...MildUtils.spacing.py2,
-  backgroundColor: MildTheme.colors.primary[500],
-};
-
-const textStyle: TextStyle = {
-  ...MildUtils.typography.textBase,
-  ...MildUtils.typography.fontMedium,
-  color: MildTheme.semanticColors.light.foreground,
-};
-\`\`\`
-
-## Custom Hook for Theme
-
-\`\`\`javascript
-import { useState, useEffect } from 'react';
-import { Appearance } from 'react-native';
-import { MildTheme } from './theme/MildTheme';
-
-export const useMildTheme = () => {
-  const [isDark, setIsDark] = useState(Appearance.getColorScheme() === 'dark');
-
-  useEffect(() => {
-    const subscription = Appearance.addChangeListener(({ colorScheme }) => {
-      setIsDark(colorScheme === 'dark');
-    });
-    return () => subscription.remove();
-  }, []);
-
-  const theme = isDark ? MildTheme.semanticColors.dark : MildTheme.semanticColors.light;
-  
-  return { theme, isDark, setIsDark };
-};
-\`\`\`
-
-## Platform-Specific Styles
-
-\`\`\`javascript
-import { Platform } from 'react-native';
-
-const platformStyles = StyleSheet.create({
-  card: {
-    ...MildUtils.spacing.p4,
-    ...MildUtils.borders.roundedLg,
-    ...(Platform.OS === 'ios' ? MildUtils.shadows.shadowLg : { elevation: 4 }),
-  },
-});
-\`\`\`
-
-This React Native theme maintains 100% design consistency with your mild-ui web application across all platforms!
+This React Native theme maintains 100% design consistency with your mild-ui web application.
 `;
 }
 

--- a/packages/core/scripts/generate-utility-docs.js
+++ b/packages/core/scripts/generate-utility-docs.js
@@ -556,40 +556,8 @@ ${category.description}
     markdown += '\n';
   });
 
-  // Add usage examples
-  markdown += `## Usage Examples
-
-### Basic Layout
-\`\`\`html
-<div class="mild-flex mild-items-center mild-justify-between mild-p-4">
-  <h1 class="mild-text-xl mild-font-bold mild-text-gray-900">Title</h1>
-  <button class="mild-bg-blue-500 mild-text-white mild-px-4 mild-py-2 mild-radius-md">
-    Button
-  </button>
-</div>
-\`\`\`
-
-### Responsive Design
-\`\`\`html
-<div class="mild-grid mild-grid-cols-1 md:mild-grid-cols-2 lg:mild-grid-cols-3 mild-gap-4">
-  <div class="mild-p-6 mild-bg-white mild-radius-lg mild-shadow">Card 1</div>
-  <div class="mild-p-6 mild-bg-white mild-radius-lg mild-shadow">Card 2</div>
-  <div class="mild-p-6 mild-bg-white mild-radius-lg mild-shadow">Card 3</div>
-</div>
-\`\`\`
-
-### Dark Mode
-\`\`\`html
-<html data-theme="dark">
-<body class="mild-bg-gray-900 mild-text-gray-100">
-  <div class="mild-p-4 mild-bg-gray-800 mild-radius-md">
-    Dark mode content
-  </div>
-</body>
-</html>
-\`\`\`
-
-## Design Tokens
+  // Add design tokens section
+  markdown += `## Design Tokens
 
 ### Color Palettes
 ${Object.entries(tokens.colors).map(([name, palette]) => {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - "packages/*"
   - "storybook/*"
-  - "examples/*"
   - "docs"

--- a/pnpm-workspace.yaml.backup
+++ b/pnpm-workspace.yaml.backup
@@ -1,5 +1,4 @@
 packages:
   - "packages/*"
   - "storybook/*"
-  - "examples/*"
   - "docs"


### PR DESCRIPTION
Remove examples-related npm scripts and CI deployment steps since examples are no longer needed. Clean up main documentation index page by removing examples references.